### PR TITLE
Inclusion of code to allow 'any_mechanism_prob'

### DIFF
--- a/src/.gitignore
+++ b/src/.gitignore
@@ -1,0 +1,46 @@
+# Compiled source #
+###################
+*.o
+*.pyc
+*.py~
+corona3d_2020
+../*.o
+../*.py~
+
+# Runtime I/O files for models #
+#####################################
+output/*.out
+output/*/
+output/*/*.out
+
+# Python scripts
+################
+*.py
+
+# Outputs from analysis/plotting scripts
+########################################
+output/*.pdf
+output/*.png
+output/*.pptx
+output/*.csv
+output/*.csv~
+*.pdf
+*.svg
+*.png
+*.xlsx
+*.csv
+*.txt
+*.txt~
+
+
+../collider2.o
+
+# other #
+######################
+../.DS_Store
+.DS_Store
+Distribution_Hot_H_copy.cpp
+o2plus_dr_rates.dat
+
+*#
+

--- a/src/Distribution_Hot_H.cpp
+++ b/src/Distribution_Hot_H.cpp
@@ -15,8 +15,6 @@ Distribution_Hot_H::Distribution_Hot_H(Planet my_p, double ref_h, double ref_T)
 	m_HCOplus = 29.0175*constants::amu;
 	m_CO = 28.0101*constants::amu;
 	source = "";
-	H_Hplus_rate_coeff = 8.7e-10;  // default coeff from Rodriguez 1984
-	HCOplus_DR_rate_coeff = 2.0e-7;  // default coeff from Fox 2015
 	global_rate = 0.0;
 
 	temp_profile.resize(4);
@@ -111,8 +109,17 @@ Distribution_Hot_H::Distribution_Hot_H(Planet my_p, double ref_h, double ref_T)
 		{
 			electron_prof_filename = values[i];
 		}
+		else if (parameters[i] == "any_mechanism_energy")
+		{
+		  any_mechanism_energy = stod(values[i]);
+		}
+		else if (parameters[i] == "any_mechanism_alt_bin")
+		{
+		  any_mechanism_alt_bin = stoi(values[i]);
+		}
+		    
 	}
-
+	
 	common::import_csv(temp_prof_filename, temp_profile[0], temp_profile[1], temp_profile[2], temp_profile[3]);
 	common::import_csv(H_prof_filename, H_profile[0], H_profile[1]);
 	common::import_csv(Hplus_prof_filename, Hplus_profile[0], Hplus_profile[1]);
@@ -149,7 +156,7 @@ void Distribution_Hot_H::init(shared_ptr<Particle> p)
 	}
 	else if (source == "any_mechanism_prob")
 	{
-	        init_any_mechanism_prob_particle(p);
+	         init_any_mechanism_prob_particle(p);
 	}
 }
 
@@ -373,7 +380,7 @@ void Distribution_Hot_H::init_HCOplus_DR_particle(shared_ptr<Particle> p)
 	p->init_particle(x, y, z, vx, vy, vz);
 }
 
-// init particle using any_mechanism_prob (to roughly estimate escape rate for any mechanism, for a 5eV distribution of particles produced at a certain altitude)
+// init particle using any_mechanism_prob (to compute  escape rate of H atoms born at a certain altitude)
 void Distribution_Hot_H::init_any_mechanism_prob_particle(shared_ptr<Particle> p)
 {
 	// altitude distribution for hot H
@@ -396,7 +403,7 @@ void Distribution_Hot_H::init_any_mechanism_prob_particle(shared_ptr<Particle> p
 	}
 
 	// Select Electronic Channel
-	double Ei = 5;       // (eV). Assume representative excess energy of x eV for all mechanisms, with none to electronic, vibrational or rotational levels
+	double Ei = any_mechanism_energy;       // (eV). Assume representative excess energy of x eV for all mechanisms, with none to electronic, vibrational or rotational levels
 
 	// convert energy to ergs
 	Ei = Ei*constants::ergev;
@@ -411,7 +418,7 @@ void Distribution_Hot_H::init_any_mechanism_prob_particle(shared_ptr<Particle> p
 	double vy = v*sqrt(1-u*u)*sin(phi);
 	double vz = v*u;
 
-       	std::cout << "alt " << alt/1e5 << "\t" << v << "\n"; // This line allows check that particles are being produced at the altitude (km) and with the velocity (cm/s) expected
+       	//std::cout << "alt " << alt/1e5 << "\t" << v << "\n"; // This line allows check that particles are being produced at the altitude (km) and with the velocity (cm/s) expected
 
 	// Don't add initial translational momentum of reactants -  this is acceptable because the velocities are isotropic, so there will be a net 0 effect on v
 	p->init_particle(x, y, z, vx, vy, vz);
@@ -657,7 +664,7 @@ void Distribution_Hot_H::make_any_mechanism_prob_CDF(double lower_alt, double up
 	{
 	        any_mechanism_prob_CDF[1][i] = lower_alt + bin_size*i;
 		// the section below produces all test particles in a single bin
-		if (i == 0) // Choose the altitude bin at which particles are produced. If using Mars, max i is 3199; if using Venus, max i is 3099
+                if (i == any_mechanism_alt_bin) // any_mechanism_alt_bin is the altitude bin at which particles are produced (set in Hot_H.cfg)
 		{
 		        any_mechanism_prob_CDF[0][i] = 1;
 		}

--- a/src/Distribution_Hot_H.cpp
+++ b/src/Distribution_Hot_H.cpp
@@ -336,10 +336,14 @@ void Distribution_Hot_H::init_HCOplus_DR_particle(shared_ptr<Particle> p)
 	}
 
 	// convert energy to ergs
+	Ei = 5.0;
 	Ei = Ei*constants::ergev;
+	//Ei = Ei*constants::jev;
+	std::cout << constants::ergev << "\n";
 
 	// Translational Energy of H Resulting from Dissociative Recombination of HCO+
-	double v = sqrt(2.0*Ei / (m_H + (m_H*m_H/m_CO)));
+	double v = sqrt(2.0*Ei / (m_H));// + (m_H*m_H/m_CO)));
+	std::cout << 2*Ei << " " << m_H << " " << v << "\n";
 
 	// spherically isotropic velocity vector
 	phi = constants::twopi*common::get_rand();

--- a/src/Distribution_Hot_H.hpp
+++ b/src/Distribution_Hot_H.hpp
@@ -26,13 +26,14 @@ private:
 	double HCOplus_DR_rate_coeff;  // [cm^3/s] rate coefficient for HCO+ + e -> H* + CO
 	double global_rate;    // [s^-1] set by chosen production method; calling function needs to divide this by 2 to get hemispherical rate
 	string source;         // which source to use when initializing particles ('H_Hplus' or 'HCOplus_DR')
-	vector<vector<double>> H_profile;
+        vector<vector<double>> H_profile;
 	vector<vector<double>> Hplus_profile;
 	vector<vector<double>> HCOplus_profile;
 	vector<vector<double>> electron_profile;
 	vector<vector<double>> temp_profile;
 	vector<vector<double>> H_Hplus_CDF;
 	vector<vector<double>> HCOplus_DR_CDF;
+        vector<vector<double>> any_mechanism_prob_CDF;
 
 	// scans HCOplus_DR_CDF for new particle radius
 	double get_new_radius_HCOplus_DR();
@@ -40,14 +41,17 @@ private:
 	// scans H_Hplus_CDF for new particle radius
 	double get_new_radius_H_Hplus();
 
-	// init particle using H_Hplus mechanism
+        // scans any_mechanism_prob_CDF for new particle radius
+        double get_new_radius_any_mechanism_prob();
+
+        // init particle using H_Hplus mechanism
 	void init_H_Hplus_particle(shared_ptr<Particle> p);
 
 	// init particle using HCOplus_DR mechanism
 	void init_HCOplus_DR_particle(shared_ptr<Particle> p);
 
   	// init particle using any_mechanism_prob (to estimate escape probability)
-	void init_any_mechanism_prob_particle(shared_ptr<Particle> p);
+        void init_any_mechanism_prob_particle(shared_ptr<Particle> p);
 
 	// generate HCOplus_DR_CDF for given altitude range using imported density/temp profiles
 	void make_HCOplus_DR_CDF(double lower_alt, double upper_alt);
@@ -56,7 +60,7 @@ private:
 	void make_H_Hplus_CDF(double lower_alt, double upper_alt);
 
   	// generate any_mechanism_prob_CDF for given altitude range using imported density/temp profiles (to estimate escape probability)
-	void make_any_mechanism_prob_CDF(double lower_alt, double upper_alt);
+        void make_any_mechanism_prob_CDF(double lower_alt, double upper_alt);
 };
 
 #endif /* DISTRIBUTION_HOT_H_HPP_ */

--- a/src/Distribution_Hot_H.hpp
+++ b/src/Distribution_Hot_H.hpp
@@ -46,11 +46,17 @@ private:
 	// init particle using HCOplus_DR mechanism
 	void init_HCOplus_DR_particle(shared_ptr<Particle> p);
 
+  	// init particle using any_mechanism_prob (to estimate escape probability)
+	void init_any_mechanism_prob_particle(shared_ptr<Particle> p);
+
 	// generate HCOplus_DR_CDF for given altitude range using imported density/temp profiles
 	void make_HCOplus_DR_CDF(double lower_alt, double upper_alt);
 
 	// generate H_Hplus_CDF for given altitude range using imported density/temp profiles
 	void make_H_Hplus_CDF(double lower_alt, double upper_alt);
+
+  	// generate any_mechanism_prob_CDF for given altitude range using imported density/temp profiles (to estimate escape probability)
+	void make_any_mechanism_prob_CDF(double lower_alt, double upper_alt);
 };
 
 #endif /* DISTRIBUTION_HOT_H_HPP_ */

--- a/src/Distribution_Hot_H.hpp
+++ b/src/Distribution_Hot_H.hpp
@@ -22,8 +22,10 @@ private:
 	double m_Hplus;            // [g] H+ ion mass
 	double m_HCOplus;          // [g] HCO+ ion mass
 	double m_CO;               // [g] CO mass
-	double H_Hplus_rate_coeff; // [cm^3/s] rate coefficient for H+ + H -> H* + H+
+  	double H_Hplus_rate_coeff; // [cm^3/s] rate coefficient for H+ + H -> H* + H+
 	double HCOplus_DR_rate_coeff;  // [cm^3/s] rate coefficient for HCO+ + e -> H* + CO
+        double any_mechanism_energy; // [eV] energy given to H atom when 'any_mechanism_prob' source chose (producing H at single altitude)
+        int any_mechanism_alt_bin; // altitude bin in which H atoms are produced when source is 'any_mechanism_prob'
 	double global_rate;    // [s^-1] set by chosen production method; calling function needs to divide this by 2 to get hemispherical rate
 	string source;         // which source to use when initializing particles ('H_Hplus' or 'HCOplus_DR')
         vector<vector<double>> H_profile;

--- a/src/Hot_H.cfg
+++ b/src/Hot_H.cfg
@@ -10,7 +10,7 @@ HCOplus_DR_rate_coeff     2.0e-7      # [cm^3 s^-1]  from Fox 2015
 ##################
 # Venus config 1 #
 ##################
-#source                 H_Hplus     #valid choices are 'H_Hplus' or 'HCOplus_DR
+#source                 H_Hplus     #valid choices are 'H_Hplus' or 'any_mechanism_prob'
 #profile_bottom         90e5        #[cm] bottom altitude boundary of atmospheric profiles
 #profile_top            400e5       #[cm] top altitude boundary of atmospheric profiles
 #temp_prof_filename     ./inputs/Venus/VenusTemp_LSA_FoxSung2001.csv
@@ -20,7 +20,7 @@ HCOplus_DR_rate_coeff     2.0e-7      # [cm^3 s^-1]  from Fox 2015
 #################
 # Mars config 1 #
 #################
-source                   HCOplus_DR #any_mechanism_prob     #valid choices are 'H_Hplus' or 'HCOplus_DR'
+source                   any_mechanism_prob     #valid choices are 'H_Hplus' or 'HCOplus_DR.' To estimate escape probability by running models producing all particles at one altitude, use 'any_mechanism_prob.'
 profile_bottom           80e5        #[cm] bottom altitude boundary of atmospheric profiles
 profile_top              400e5       #[cm] top altitude boundary of atmospheric profiles
 temp_prof_filename       ./inputs/Mars/MarsTempLSA_Fox2015.csv

--- a/src/Hot_H.cfg
+++ b/src/Hot_H.cfg
@@ -22,7 +22,7 @@ any_mechanism_alt_bin     200         # altitude bin in which H atoms are produc
 #################
 # Mars config 1 #
 #################
-source                   any_mechanism_prob     #valid choices are 'H_Hplus' or 'HCOplus_DR.' To estimate escape probability by running models producing all particles at one altitude, use 'any_mechanism_prob.'
+source                   HCOplus_DR     #valid choices are 'H_Hplus' or 'HCOplus_DR.' To estimate escape probability by running models producing all particles at one altitude, use 'any_mechanism_prob.'
 profile_bottom           80e5        #[cm] bottom altitude boundary of atmospheric profiles
 profile_top              400e5       #[cm] top altitude boundary of atmospheric profiles
 temp_prof_filename       ./inputs/Mars/MarsTempLSA_Fox2015.csv

--- a/src/Hot_H.cfg
+++ b/src/Hot_H.cfg
@@ -20,7 +20,7 @@ HCOplus_DR_rate_coeff     2.0e-7      # [cm^3 s^-1]  from Fox 2015
 #################
 # Mars config 1 #
 #################
-source                   HCOplus_DR     #valid choices are 'H_Hplus' or 'HCOplus_DR'
+source                   HCOplus_DR #any_mechanism_prob     #valid choices are 'H_Hplus' or 'HCOplus_DR'
 profile_bottom           80e5        #[cm] bottom altitude boundary of atmospheric profiles
 profile_top              400e5       #[cm] top altitude boundary of atmospheric profiles
 temp_prof_filename       ./inputs/Mars/MarsTempLSA_Fox2015.csv

--- a/src/Hot_H.cfg
+++ b/src/Hot_H.cfg
@@ -6,6 +6,8 @@
 
 H_Hplus_rate_coeff        8.7e-10     # [cm^3 s^-1]  from Rodriguez 1984
 HCOplus_DR_rate_coeff     2.0e-7      # [cm^3 s^-1]  from Fox 2015
+any_mechanism_energy      5.0         # [eV] energy given to H atom when source is 'any_mechanism_prob'
+any_mechanism_alt_bin     200         # altitude bin in which H atoms are produced when source is 'any_mechanism_prob.' If profile_bottom = 80e5 (Mars), max is 3199; if profile_bottom = 90e5 (Venus), max is 3099, assuming bin size = 1e5 cm.
 
 ##################
 # Venus config 1 #

--- a/src/Particle.cpp
+++ b/src/Particle.cpp
@@ -62,7 +62,7 @@ void Particle::do_collision(shared_ptr<Particle> target, double theta, double ti
 
 	double alpha = atan2(velocity[1], velocity[0]);
 	double phi = atan2(velocity[2], sqrt(velocity[0]*velocity[0] + velocity[1]*velocity[1]));
-	double gamma = constants::twopi*common::get_rand();  // bg temporary comment - gamma random no. from uniform distribution between 0 and 2pi
+	double gamma = constants::twopi*common::get_rand();  //  gamma random no. from uniform distribution between 0 and 2pi
 
 	Matrix<double, 3, 1> vp;
 	vp[0] = v1*cos(alpha)*cos(phi-theta);
@@ -91,9 +91,9 @@ void Particle::do_collision(shared_ptr<Particle> target, double theta, double ti
 	// update post-collision velocity
 	if (traced)
 	{
-	  v_before = get_total_v()*1e-5; // bg temporary comment - thsi is sqrt(vx^2 + vy^2 + vz^2)
+	  v_before = get_total_v()*1e-5; //  sqrt(vx^2 + vy^2 + vz^2)
 	}
-	velocity = vcm.array() + vrel1.array(); // bg temporary comment - here is where velocity changes
+	velocity = vcm.array() + vrel1.array(); // here is where velocity changes
 
 	// in case you need the updated collision partner velocity for something
 	// targ_v = vcm.array() - ((my_mass / targ_mass) * vrel1.array());

--- a/src/Particle.cpp
+++ b/src/Particle.cpp
@@ -58,11 +58,11 @@ void Particle::do_collision(shared_ptr<Particle> target, double theta, double ti
 	// double v2 = sqrt(v2v[0]*v2v[0] + v2v[1]*v2v[1] + v2v[2]*v2v[2]);  // particle 2 c-o-m scalar velocity
 
 	// unit vector parallel to particle 1 velocity
-	Matrix<double, 3, 1> r = velocity.array() / sqrt(velocity[0]*velocity[0] + velocity[1]*velocity[1] + velocity[2]*velocity[2]);
+	Matrix<double, 3, 1> r = velocity.array() / sqrt(velocity[0]*velocity[0] + velocity[1]*velocity[1] + velocity[2]*velocity[2]); // velocity is a three-component vector: vx, vy, vz, so r is the velocity vector normalised to -1 to 1
 
 	double alpha = atan2(velocity[1], velocity[0]);
 	double phi = atan2(velocity[2], sqrt(velocity[0]*velocity[0] + velocity[1]*velocity[1]));
-	double gamma = constants::twopi*common::get_rand();
+	double gamma = constants::twopi*common::get_rand();  // bg temporary comment - gamma random no. from uniform distribution between 0 and 2pi
 
 	Matrix<double, 3, 1> vp;
 	vp[0] = v1*cos(alpha)*cos(phi-theta);
@@ -85,14 +85,15 @@ void Particle::do_collision(shared_ptr<Particle> target, double theta, double ti
 	Rrg(2, 1) = r[1]*r[2]*Vg-r[0]*Sg;
 	Rrg(2, 2) = r[2]*r[2]*Vg+Cg;
 
+
 	Matrix<double, 3, 1> vrel1 = Rrg * vp;
 
 	// update post-collision velocity
 	if (traced)
 	{
-		v_before = get_total_v()*1e-5;
+	  v_before = get_total_v()*1e-5; // bg temporary comment - thsi is sqrt(vx^2 + vy^2 + vz^2)
 	}
-	velocity = vcm.array() + vrel1.array();
+	velocity = vcm.array() + vrel1.array(); // bg temporary comment - here is where velocity changes
 
 	// in case you need the updated collision partner velocity for something
 	// targ_v = vcm.array() - ((my_mass / targ_mass) * vrel1.array());

--- a/src/Particle.hpp
+++ b/src/Particle.hpp
@@ -8,8 +8,9 @@
 #ifndef PARTICLE_HPP_
 #define PARTICLE_HPP_
 
-#include <eigen3/Eigen/Core>  // uncomment for Ubuntu
+//#include <eigen3/Eigen/Core>  // uncomment for Ubuntu
 //#include </usr/local/Cellar/eigen/3.3.9/include/eigen3/Eigen/Core>  // uncomment for Mac
+#include </opt/local/include/eigen3/Eigen/Core>
 #include "Common_Functions.hpp"
 using namespace Eigen;
 

--- a/src/Particle.hpp
+++ b/src/Particle.hpp
@@ -8,9 +8,9 @@
 #ifndef PARTICLE_HPP_
 #define PARTICLE_HPP_
 
-//#include <eigen3/Eigen/Core>  // uncomment for Ubuntu
+#include <eigen3/Eigen/Core>  // uncomment for Ubuntu
 //#include </usr/local/Cellar/eigen/3.3.9/include/eigen3/Eigen/Core>  // uncomment for Mac
-#include </opt/local/include/eigen3/Eigen/Core>
+//#include </opt/local/include/eigen3/Eigen/Core> // uncomment for Mac option 2
 #include "Common_Functions.hpp"
 using namespace Eigen;
 

--- a/src/corona3d_2020.cfg
+++ b/src/corona3d_2020.cfg
@@ -11,9 +11,9 @@
 ## Any additional columns following the first two are ignored. ##
 #################################################################
 
-num_testparts   1000       #number of test particles in simulation
-part_type       H          #particle type to be tracked (H, O, N2, CO, or CO2)
-dist_type       Hot_H       #initial distribution type (Hot_O, Hot_H, MB, or Import (must set import file paths below))
+num_testparts   100000       #number of test particles in simulation
+part_type       O          #particle type to be tracked (H, O, N2, CO, or CO2)
+dist_type       Hot_O       #initial distribution type (Hot_O, Hot_H, MB, or Import (must set import file paths below))
 #pos_infile      pos.in      #filename of positions to import (3-column file of x, y, z coordinates in cm)
 #vel_infile      vel.in      #filename of velocities to import (3-column file of vx, vy, vz values in cm/s)
 timesteps       90000000     #number of total timesteps in simulation
@@ -61,10 +61,10 @@ ion_densities
 
 num_bgparts  4  #number of different background species to use
 
-bg_part1_config    ./inputs/O_Mars_HotH.cfg
-bg_part2_config    ./inputs/N2_Mars_HotH.cfg
-bg_part3_config    ./inputs/CO_Mars_HotH.cfg
-bg_part4_config    ./inputs/CO2_Mars_HotH.cfg
+bg_part1_config    ./inputs/O_Mars_HotO.cfg
+bg_part2_config    ./inputs/N2_Mars_HotO.cfg
+bg_part3_config    ./inputs/CO_Mars_HotO.cfg
+bg_part4_config    ./inputs/CO2_Mars_HotO.cfg
 
 
 #########################################################
@@ -131,7 +131,3 @@ EDF_47_alt         4700
 EDF_48_alt         4800
 EDF_49_alt         4900
 EDF_50_alt         5000
-
-
-
-

--- a/src/corona3d_2020.cfg
+++ b/src/corona3d_2020.cfg
@@ -11,9 +11,9 @@
 ## Any additional columns following the first two are ignored. ##
 #################################################################
 
-num_testparts   100000       #number of test particles in simulation
-part_type       O           #particle type to be tracked (H, O, N2, CO, or CO2)
-dist_type       Hot_O       #initial distribution type (Hot_O, Hot_H, MB, or Import (must set import file paths below))
+num_testparts   1000       #number of test particles in simulation
+part_type       H          #particle type to be tracked (H, O, N2, CO, or CO2)
+dist_type       Hot_H       #initial distribution type (Hot_O, Hot_H, MB, or Import (must set import file paths below))
 #pos_infile      pos.in      #filename of positions to import (3-column file of x, y, z coordinates in cm)
 #vel_infile      vel.in      #filename of velocities to import (3-column file of vx, vy, vz values in cm/s)
 timesteps       90000000     #number of total timesteps in simulation
@@ -61,10 +61,10 @@ ion_densities
 
 num_bgparts  4  #number of different background species to use
 
-bg_part1_config    ./inputs/O_Mars_HotO.cfg
-bg_part2_config    ./inputs/N2_Mars_HotO.cfg
-bg_part3_config    ./inputs/CO_Mars_HotO.cfg
-bg_part4_config    ./inputs/CO2_Mars_HotO.cfg
+bg_part1_config    ./inputs/O_Mars_HotH.cfg
+bg_part2_config    ./inputs/N2_Mars_HotH.cfg
+bg_part3_config    ./inputs/CO_Mars_HotH.cfg
+bg_part4_config    ./inputs/CO2_Mars_HotH.cfg
 
 
 #########################################################

--- a/src/makefile
+++ b/src/makefile
@@ -1,57 +1,59 @@
+CFLAGS=-O2 #g -O0 -Wall -Wextra
+
 corona3d_2020: Atmosphere.o Background_Species.o Common_Functions.o Distribution_Hot_H.o Distribution_Hot_O.o Distribution_Import.o Distribution_MB.o Distribution.o Interpolator.o main.o Particle_CO.o Particle_CO2.o Particle_H.o Particle_N2.o Particle_O.o Particle.o Planet.o
-	g++ Atmosphere.o Background_Species.o Common_Functions.o Distribution_Hot_H.o Distribution_Hot_O.o Distribution_Import.o Distribution_MB.o Distribution.o Interpolator.o main.o Particle_CO.o Particle_CO2.o Particle_H.o Particle_N2.o Particle_O.o Particle.o Planet.o -o corona3d_2020
-	
+	g++ $(CFLAGS) Atmosphere.o Background_Species.o Common_Functions.o Distribution_Hot_H.o Distribution_Hot_O.o Distribution_Import.o Distribution_MB.o Distribution.o Interpolator.o main.o Particle_CO.o Particle_CO2.o Particle_H.o Particle_N2.o Particle_O.o Particle.o Planet.o -o corona3d_2020
+
 Atmosphere.o: Atmosphere.cpp
-	g++ -O2 -c Atmosphere.cpp
-	
+	g++ $(CFLAGS) -c Atmosphere.cpp
+
 Background_Species.o: Background_Species.cpp
-	g++ -O2 -c Background_Species.cpp
-	
+	g++ $(CFLAGS) -c Background_Species.cpp
+
 Common_Functions.o: Common_Functions.cpp
-	g++ -O2 -c Common_Functions.cpp
-	
+	g++ $(CFLAGS) -c Common_Functions.cpp
+
 Distribution_Hot_H.o: Distribution_Hot_H.cpp
-	g++ -O2 -c Distribution_Hot_H.cpp
+	g++ $(CFLAGS) -c Distribution_Hot_H.cpp
 
 Distribution_Hot_O.o: Distribution_Hot_O.cpp
-	g++ -O2 -c Distribution_Hot_O.cpp
+	g++ $(CFLAGS) -c Distribution_Hot_O.cpp
 
 Distribution_Import.o: Distribution_Import.cpp
-	g++ -O2 -c Distribution_Import.cpp
+	g++ $(CFLAGS) -c Distribution_Import.cpp
 
 Distribution_MB.o: Distribution_MB.cpp
-	g++ -O2 -c Distribution_MB.cpp
+	g++ $(CFLAGS) -c Distribution_MB.cpp
 
 Distribution.o: Distribution.cpp
-	g++ -O2 -c Distribution.cpp
+	g++ $(CFLAGS) -c Distribution.cpp
 
 Interpolator.o: Interpolator.cpp
-	g++ -O2 -c Interpolator.cpp
-	
+	g++ $(CFLAGS) -c Interpolator.cpp
+
 main.o: main.cpp
-	g++ -O2 -c main.cpp
-	
+	g++ $(CFLAGS) -c main.cpp
+
 Particle_CO.o: Particle_CO.cpp
-	g++ -O2 -c Particle_CO.cpp
-	
+	g++ $(CFLAGS) -c Particle_CO.cpp
+
 Particle_CO2.o: Particle_CO2.cpp
-	g++ -O2 -c Particle_CO2.cpp
-	
+	g++ $(CFLAGS) -c Particle_CO2.cpp
+
 Particle_H.o: Particle_H.cpp
-	g++ -O2 -c Particle_H.cpp
-	
+	g++ $(CFLAGS) -c Particle_H.cpp
+
 Particle_N2.o: Particle_N2.cpp
-	g++ -O2 -c Particle_N2.cpp
-	
+	g++ $(CFLAGS) -c Particle_N2.cpp
+
 Particle_O.o: Particle_O.cpp
-	g++ -O2 -c Particle_O.cpp
-	
+	g++ $(CFLAGS) -c Particle_O.cpp
+
 Particle.o: Particle.cpp
-	g++ -O2 -c Particle.cpp
-	
+	g++ $(CFLAGS) -c Particle.cpp
+
 Planet.o: Planet.cpp
-	g++ -O2 -c Planet.cpp
-	
+	g++ $(CFLAGS) -c Planet.cpp
+
 clean:
 	rm *.o
 	rm corona3d_2020


### PR DESCRIPTION
The main change is the inclusion of extra code in Hot_H.cfg and Distribution_Hot_H.cpp that allows the option 'any_mechanism_prob' to be chosen. Here, for either planet, all of the particles are produced at a single specified altitude with a certain specified energy.